### PR TITLE
Ehrenmitglieder hinzufügen

### DIFF
--- a/beitragsordnung.md
+++ b/beitragsordnung.md
@@ -6,6 +6,7 @@
     1. welche natürliche Personen sind: 12 €,
     2. welche keine natürlichen Personen sind: 1337€.
 1. Der Vorstand kann auf Antrag eine Befreiung von der Zahlungspflicht, oder eine Ermäßigung des Beitrages erteilen, ggf. auch rückwirkend. Der Vorstand entscheidet nach billigem Ermessen.
+5. Ehrenmitglieder sind von der Aufnahmegebühr und den Mitgliedsbeiträgen befreit.
 
 ## § 2 Vereinseintritt
 

--- a/satzung.md
+++ b/satzung.md
@@ -18,8 +18,9 @@ TODO: replace all `?` chars
     3. Die Teilnahme an Veranstaltungen im IT-Bereich,
     4. Die Förderung der Kommunitkation zwischen Technik- und Computerinteressierten Jugendlichen,
     5. Die Förderung von praktischen und künstlerischen Projekten Jugendlicher im Bereich der Computertechnik.
-3. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
+2. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
 
+3. Der Verein verfolgt ausschließlich und unmittelbar gemeinnützige Zwecke im Sinne des Abschnitts “Steuerbegünstigte Zwecke” der Abgabenordnung. Er darf keine Gewinne erzielen; er ist selbstlos tätig und verfolgt nicht in erster Linie eigenwirtschaftliche Zwecke. Die Mittel des Vereins werden ausschließlich und unmittelbar zu den satzungsgemäßen Zwecken verwendet. Die Mitglieder erhalten keine Zuwendung aus den Mitteln des Vereins. Niemand darf durch Ausgaben, die dem Zwecke des Vereins fremd sind oder durch unverhältnismäßig hohe Vergütungen begünstigt werden. 
 
 ## § 3 Mitgliedschaft
 

--- a/satzung.md
+++ b/satzung.md
@@ -26,6 +26,7 @@ TODO: replace all `?` chars
 
 1. Ordentliche Vereinsmitglieder können natürliche und juristische Personen, Handelsgesellschaften, nicht rechtsfähige Vereine sowie Anstalten und Körperschaften des öffentlichen Rechts werden.
 2. Mitglieder, deren Vereinsmitgliedschaft aufgrund satzungsgemäßer Bestimmungen ruht, sind in der Mitgliederversammlung nicht abstimmungs- oder wahlberechtigt, es sei denn es handelt sich um Beschlüsse über den Ausschluss einzelner Mitglieder. Über die Enthebung aus Ämtern entscheidet der Vorstand.
+3. Die Mitgliederversammlung kann solche Personen, die sich besondere Verdienste um den Club oder um die von ihm verfolgten satzungsgemäßen Zwecke erworben haben, zu Ehrenmitgliedern ernennen. Ehrenmitglieder haben alle Rechte eines ordentlichen Mitglieds. Sie sind von Beitragsleistungen befreit. 
 
 ### § 3a Rechte und Pflichten
 

--- a/satzung.md
+++ b/satzung.md
@@ -12,13 +12,13 @@ TODO: replace all `?` chars
 
 ## § 2 Zweck
 
-1. Der Verein fördert und unterstützt Vorhaben der Forschung, Wissenschaft und Bildung und führt diese im gesetzlichen Rahmen durch. Der Vereinszweck soll unter anderem durch folgende Mittel erreicht werden:
-    1. ??? ??? Das Teilnehmen an IT-Sicherheitswettbewerben (sog. Capture-The-Flag-Wettbewerbe),
-    2. ??? ??? Das Veranstalten von IT-Sicherheitswettbewerben (sog. Capture-The-Flag-Wettbewerbe),
-    3. ??? ??? Auffinden und ggf. Melden von Sicherheitslücken,
-    4. ??? ??? Förderung der nationalen und internationalen Kommunikation zwischen Technologie-Experten,
-    5. ??? ??? Vereinsinterne Treffen — ggf. mit externen Gästen — zum Austausch über IT-Themen.
-2. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
+1. Der Verein fördert und unterstützt Vorhaben der Forschung, Wissenschaft, Bildung und Jugendarbeit und führt diese im gesetzlichen Rahmen durch. Der Vereinszweck soll unter anderem durch folgende Mittel erreicht werden:
+    1. Die Organisation von Veranstaltungen, insbesondere für Jugendliche,
+    2. Vereinsinterne Treffen — ggf. mit externen Gästen — zum Austausch über IT-Themen,
+    3. Die Teilnahme an Veranstaltungen im IT-Bereich,
+    4. Die Förderung der Kommunitkation zwischen Technik- und Computerinteressierten Jugendlichen,
+    5. Die Förderung von praktischen und künstlerischen Projekten Jugendlicher im Bereich der Computertechnik.
+3. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
 
 
 ## § 3 Mitgliedschaft

--- a/satzung.md
+++ b/satzung.md
@@ -83,8 +83,9 @@ TODO: replace all `?` chars
     4. die Satzungsänderungen,
     5. die Genehmigung des Finanzberichts,
     6. der Erlass, Änderung und Aufhebung von Ordnungen,
-    7. die Anträge des Vorstandes und der Mitglieder, sowie
-    8. die Auflösung des Vereins.
+    7. die Anträge des Vorstandes und der Mitglieder,
+    8. die Auflösung des Vereins, sowie
+    9. die Ernennung von Ehrenmitgliedern
 2. Die Mitgliederversammlung kann an einem durch den Vorstand festgelegten Ort, im Rahmen von Netzkonferenzen zur fernmündlichen Teilnahme sowie in einer Kombination hiervon erfolgen. 
 
 ### § 6a Einberufung


### PR DESCRIPTION
Die MV kann Personen zu Ehrenmitgliedern ernennen, welche sämtliche Rechte eines ordentlichen Mitglieds haben, jedoch von der Beitragspflicht entbunden sind.