### PR TITLE
Vorstand nicht mehr "grundsätzlich" Ehrenamtlich

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -142,7 +142,7 @@ Wahlen, wie insbesondere die Wahl des Vorstandes und der Kassenprüfenden, richt
     2. ein bis zwei stellvertretenden Vorsitzenden,
     3. einem Finanzvorstand,
 1. Der Vorstandsvorsitz, die stellvertretenden Vorsitzenden und der Finanzvorstand  bilden den geschäftsführenden Vorstand. 
-2. Die Vorstandsmitglieder sind grundsätzlich ehrenamtlich tätig; sie haben Anspruch auf Erstattung notwendiger und verhältnismäßiger Auslagen.
+2. Die Vorstandsmitglieder sind ehrenamtlich tätig; sie haben Anspruch auf Erstattung notwendiger und verhältnismäßiger Auslagen.
 3. Die Vorstandsmitglieder sind von der Vorschrift des § 181 BGB befreit.
 4. Besteht der Vorstand aus weniger als zwei Mitgliedern, so sind unverzüglich Nachwahlen durchzuführen.
 


### PR DESCRIPTION
Wie in #14 vorgeschlagen, das Wort "grundsätzlich" ist rechtlich uneindeutig.
Wenn der Vorstand mal nicht mehr ehrenamtlich sein soll, kann die MV das ändern.