### PR TITLE
Minderjährige Mitglieder erlauben

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -24,7 +24,7 @@ TODO: replace all `?` chars
 
 ## § 3 Mitgliedschaft
 
-1. Ordentliche Vereinsmitglieder können natürliche und juristische Personen, Handelsgesellschaften, nicht rechtsfähige Vereine sowie Anstalten und Körperschaften des öffentlichen Rechts werden.
+1. Ordentliche Vereinsmitglieder können natürliche und juristische Personen die das 7. Lebensjahr vollendet haben, Handelsgesellschaften, nicht rechtsfähige Vereine sowie Anstalten und Körperschaften des öffentlichen Rechts werden.
 2. Mitglieder, deren Vereinsmitgliedschaft aufgrund satzungsgemäßer Bestimmungen ruht, sind in der Mitgliederversammlung nicht abstimmungs- oder wahlberechtigt, es sei denn es handelt sich um Beschlüsse über den Ausschluss einzelner Mitglieder. Über die Enthebung aus Ämtern entscheidet der Vorstand.
 
 ### § 3a Rechte und Pflichten
@@ -36,6 +36,9 @@ TODO: replace all `?` chars
 1. Der Aufnahmeantrag erfolgt in Textform gegenüber dem Vorstand. Die Mitgliedschaft steht grundsätzlich jeder Person offen. Über die Annahme des Aufnahmeantrags entscheidet der Vorstand. 
 2. Die Mitgliedschaft beginnt mit der Annahme des Aufnahmeantrags.
 3. Eine Ablehnung des Aufnahmeantrags ist nicht anfechtbar und muss nicht begründet werden.
+4. Bei Minderjährigen, die das 7. Lebensjahr vollendet haben, ist der Aufnahmeantrag zusätzlich durch die gesetzlichen Vertreter zu bestätigen. Dies ist entweder:
+    1. auf dem Mitgliedschaftsantrag geben, 
+    2. oder spätestens 4 Wochen nach Antragstellung in Textform gegenüber dem Vorstand nachzureichen. Die Mitgliedschaft ruht bis zur Bestätigung.
 
 ### § 3c Mitgliedschaftsende
 

--- a/satzung.md
+++ b/satzung.md
@@ -18,8 +18,9 @@ TODO: replace all `?` chars
     3. Die Teilnahme an Veranstaltungen im IT-Bereich,
     4. Die Förderung der Kommunitkation zwischen Technik- und Computerinteressierten Jugendlichen,
     5. Die Förderung von praktischen und künstlerischen Projekten Jugendlicher im Bereich der Computertechnik.
-3. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
+2. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
 
+3. Der Verein verfolgt ausschließlich und unmittelbar gemeinnützige Zwecke im Sinne des Abschnitts “Steuerbegünstigte Zwecke” der Abgabenordnung. Er darf keine Gewinne erzielen; er ist selbstlos tätig und verfolgt nicht in erster Linie eigenwirtschaftliche Zwecke. Die Mittel des Vereins werden ausschließlich und unmittelbar zu den satzungsgemäßen Zwecken verwendet. Die Mitglieder erhalten keine Zuwendung aus den Mitteln des Vereins. Niemand darf durch Ausgaben, die dem Zwecke des Vereins fremd sind oder durch unverhältnismäßig hohe Vergütungen begünstigt werden. 
 
 ## § 3 Mitgliedschaft
 

--- a/satzung.md
+++ b/satzung.md
@@ -12,13 +12,13 @@ TODO: replace all `?` chars
 
 ## § 2 Zweck
 
-1. Der Verein fördert und unterstützt Vorhaben der Forschung, Wissenschaft und Bildung und führt diese im gesetzlichen Rahmen durch. Der Vereinszweck soll unter anderem durch folgende Mittel erreicht werden:
-    1. ??? ??? Das Teilnehmen an IT-Sicherheitswettbewerben (sog. Capture-The-Flag-Wettbewerbe),
-    2. ??? ??? Das Veranstalten von IT-Sicherheitswettbewerben (sog. Capture-The-Flag-Wettbewerbe),
-    3. ??? ??? Auffinden und ggf. Melden von Sicherheitslücken,
-    4. ??? ??? Förderung der nationalen und internationalen Kommunikation zwischen Technologie-Experten,
-    5. ??? ??? Vereinsinterne Treffen — ggf. mit externen Gästen — zum Austausch über IT-Themen.
-2. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
+1. Der Verein fördert und unterstützt Vorhaben der Forschung, Wissenschaft, Bildung und Jugendarbeit und führt diese im gesetzlichen Rahmen durch. Der Vereinszweck soll unter anderem durch folgende Mittel erreicht werden:
+    1. Die Organisation von Veranstaltungen, insbesondere für Jugendliche,
+    2. Vereinsinterne Treffen — ggf. mit externen Gästen — zum Austausch über IT-Themen,
+    3. Die Teilnahme an Veranstaltungen im IT-Bereich,
+    4. Die Förderung der Kommunitkation zwischen Technik- und Computerinteressierten Jugendlichen,
+    5. Die Förderung von praktischen und künstlerischen Projekten Jugendlicher im Bereich der Computertechnik.
+3. Der Verein fördert und unterstützt Vorhaben, um die Zusammenarbeit zwischen den Mitgliedern zu verbessern.
 
 
 ## § 3 Mitgliedschaft


### PR DESCRIPTION
Minderjähre, die das 7. Lebensjahr beendet haben sind eingeschränkt geschäftsfähig.
Sie dürfen Vereinsmitgliedschaft beantragen auch ohne ihre Eltern, aber wenn die Mitgliedschaft nicht nur vorteilhaft für sie ist (sprich, wenn sie Pflichten haben, also Beitrag zahlen MÜSSEN), müssen die Erziehungsberechtigten ihr Einverständnis geben.

Ich schlage vor wir entfernen entweder den Beitrag für Minderjährige, oder wir nehmen die hier vorgeschlagenen Änderungen, um es auch Minderjährigen zu ermöglichen auf den Geekends selbstständig beizutreten, und den Beitritt nachträglich rechtlich gültig zu machen.