### PR TITLE
Austrittserklärung mit vier Wochen zum Ende des Geschäftsjahres

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -44,7 +44,7 @@ TODO: replace all `?` chars
     3. Auflösung und Erlöschen von juristischen Personen, Handelsgesellschaften, nicht rechtsfähigen Vereinen sowie Anstalten und Körperschaften des öffentlichen Rechts oder
     4. Ausschluss.
     5. ??? dem 27. Geburtstag
-2. Der Austritt wird durch Willenserklärung in Textform gegenüber dem Vorstand vollzogen. Der Austritt ist jederzeit mit einer Frist von vier Wochen möglich.
+2. Der Austritt wird durch Willenserklärung in Textform gegenüber dem Vorstand vollzogen. Der Austritt ist nur mit einer Frist von vier Wochen zum Ende des Geschäftsjahres möglich.
 3. Die Beitragspflicht für das laufende Beitragsjahr bleibt unberührt. Eine Erstattung bereits vereinnahmter Beiträge erfolgt nicht.
 
 ### § 3d Ausschluss


### PR DESCRIPTION
In anderen Vereinen ist es mWn. üblich, dass Mitgliedschaften zum Ende von Quartalen bzw. Jahren beendet werden kann.

Insgesamt glaube ich, dass dies auch ein bisschen Struktur rein bringt und gewisse Dinge einfach nur einmal im Quartal erledigt werden müssen und nicht ad-hoc im Vier-Wochen Takt.