### PR TITLE
Vorstandsausschluss von §181 BGB entfernen

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -143,8 +143,7 @@ Wahlen, wie insbesondere die Wahl des Vorstandes und der Kassenprüfenden, richt
     3. einem Finanzvorstand,
 1. Der Vorstandsvorsitz, die stellvertretenden Vorsitzenden und der Finanzvorstand  bilden den geschäftsführenden Vorstand. 
 2. Die Vorstandsmitglieder sind ehrenamtlich tätig; sie haben Anspruch auf Erstattung notwendiger und verhältnismäßiger Auslagen.
-3. Die Vorstandsmitglieder sind von der Vorschrift des § 181 BGB befreit.
-4. Besteht der Vorstand aus weniger als zwei Mitgliedern, so sind unverzüglich Nachwahlen durchzuführen.
+3. Besteht der Vorstand aus weniger als zwei Mitgliedern, so sind unverzüglich Nachwahlen durchzuführen.
 
 ### § 7a Besetzung des Vorstandes
 


### PR DESCRIPTION
Da steht eine Zeile, dass der Vorstand von §181 BGB ausgeschlossen ist, sprich, im Namen des Vereins mit sich selbst Geschäfte machen dürfen. Weiß ich nicht wofür wir das brauchen.

Das ist ja Gesetz aus gutem Grund, zum Schutz von Vereinen. Der einzige Grund warum es Sinn machen würde das auszuhebeln, wäre wenn der Vorstand als Mitarbeiter aufgenommen werden sollte, denn dafür ist der Vorstand nicht allein bevollmächtigt, da bräuchte es den ganzen Vorstand, und das geht dann halt glaube ich nicht wenn die dafür stimmen sich selbst als Mitarbeiter zu nehmen.

Allerdings, ich glaube zum einen müsste ja Vorstands Mehrheit genügen, also könnte man selbst sich enthalten, aber ich glaube Vorstände dürfen auch nicht bezahlt werden.

Close #13 