### PR TITLE
Remove redundant clause regarding auditors in bylaws

### DIFF
--- a/satzung.md
+++ b/satzung.md
@@ -177,8 +177,7 @@ Wahlen, wie insbesondere die Wahl des Vorstandes und der Kassenprüfenden, richt
 
 ### § 7c Beschlussfassung des Vorstandes
 
-1. Zu den Vorstandssitzungen lädt der Vorsitz ein. Die Einberufung hat zu erfolgen, wenn mindestens ein Vorstandsmitglied dies in Textform verlangt. 
-
+1. Zu den Vorstandssitzungen lädt der Vorsitz ein. Die Einberufung hat zu erfolgen, wenn mindestens ein Vorstandsmitglied dies in Textform verlangt.
 2. Der Vorstand ist beschlussfähig, wenn die Mehrheit der Vorstandsmitglieder anwesend ist. 
 3. Beschlüsse werden mit einfacher Mehrheit der anwesenden Mitglieder gefasst. Bei Stimmengleichheit gilt ein Antrag als abgelehnt. 
 4. Beschlüsse können auch im Umlaufverfahren, fernmündlich, telegrafisch, fernschriftlich, im Rahmen von Netzkonferenzen oder ähnlichem gefasst werden. 

--- a/satzung.md
+++ b/satzung.md
@@ -186,7 +186,7 @@ Wahlen, wie insbesondere die Wahl des Vorstandes und der Kassenprüfenden, richt
 
 ### § 7d Kassenprüfung
 
-1. Die Mitgliederversammlung wählt ein bis zwei Kassenprüfende, die nicht Vorstandsmitglieder sind, auf die Dauer von zwei Jahren. Wiederwahl ist zulässig. Durch Beschluss kann auf die Bestellung von Kassenprüfenden unter besonderen Umständen verzichtet werden.
+1. Die Mitgliederversammlung wählt ein bis zwei Kassenprüfende, die nicht Vorstandsmitglieder sind, auf die Dauer von zwei Jahren. Wiederwahl ist zulässig.
 2. Die Kassenprüfung erfolgt nach Ablauf eines jeden Geschäftsjahres und prüft die rechnerische Richtigkeit der Buch- und Kassenführung. 
 3. Nach Durchführung ihrer Prüfung informieren die Kassenprüfenden den Vorstand von ihrem Prüfungsergebnis.
 4. Die Kassenprüfenden erstatten Bericht in der nächstfolgenden ordentlichen Mitgliederversammlung.


### PR DESCRIPTION
Eliminate unnecessary wording about the appointment of auditors to streamline the bylaws.